### PR TITLE
Allow multiple configurations of Nori

### DIFF
--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -9,7 +9,7 @@ module Nori
   # Translates the given +xml+ to a Hash. Accepts an optional +parser+ to use.
   def parse(xml, parser = nil)
     return {} if xml.blank?
-    Parser.parse xml, parser
+    Parser.parse xml, parser, self
   end
 
   # Sets the +parser+ to use.

--- a/lib/nori/parser.rb
+++ b/lib/nori/parser.rb
@@ -27,8 +27,8 @@ module Nori
 
     # Returns the parsed +xml+ using the parser to use. Raises an +ArgumentError+
     # unless the optional or default +parser+ exists.
-    def self.parse(xml, parser = nil)
-      load_parser(parser).parse xml
+    def self.parse(xml, parser = nil, nori = Nori)
+      load_parser(parser).parse(xml, nori)
     end
 
   private

--- a/lib/nori/parser/nokogiri.rb
+++ b/lib/nori/parser/nokogiri.rb
@@ -9,13 +9,14 @@ module Nori
     module Nokogiri
 
       class Document < ::Nokogiri::XML::SAX::Document
+        attr_accessor :nori
 
         def stack
           @stack ||= []
         end
 
         def start_element(name, attrs = [])
-          stack.push Nori::XMLUtilityNode.new(name, Hash[*attrs.flatten])
+          stack.push Nori::XMLUtilityNode.new(nori, name, Hash[*attrs.flatten])
         end
 
         def end_element(name)
@@ -33,8 +34,9 @@ module Nori
 
       end
 
-      def self.parse(xml)
+      def self.parse(xml, nori)
         document = Document.new
+        document.nori = nori
         parser = ::Nokogiri::XML::SAX::Parser.new document
         parser.parse xml
         document.stack.length > 0 ? document.stack.pop.to_hash : {}

--- a/lib/nori/parser/rexml.rb
+++ b/lib/nori/parser/rexml.rb
@@ -8,7 +8,7 @@ module Nori
     # REXML pull parser.
     module REXML
 
-      def self.parse(xml)
+      def self.parse(xml, nori)
         stack = []
         parser = ::REXML::Parsers::BaseParser.new(xml)
 
@@ -20,7 +20,7 @@ module Nori
           when :end_doctype, :start_doctype
             # do nothing
           when :start_element
-            stack.push Nori::XMLUtilityNode.new(event[1], event[2])
+            stack.push Nori::XMLUtilityNode.new(nori, event[1], event[2])
           when :end_element
             if stack.size > 1
               temp = stack.pop

--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -59,15 +59,16 @@ module Nori
 
     self.available_typecasts = self.typecasts.keys
 
-    def initialize(name, normalized_attributes = {})
+    def initialize(nori, name, normalized_attributes = {})
       # unnormalize attribute values
       attributes = Hash[* normalized_attributes.map do |key, value|
         [ key, unnormalize_xml_entities(value) ]
       end.flatten]
 
+      @nori = nori
       @name = name.tr("-", "_")
-      @name = @name.split(":").last if Nori.strip_namespaces?
-      @name = Nori.convert_tag(@name) if Nori.convert_tags?
+      @name = @name.split(":").last if @nori.strip_namespaces?
+      @name = @nori.convert_tag(@name) if @nori.convert_tags?
 
       # leave the type alone if we don't know what it is
       @type = self.class.available_typecasts.include?(attributes["type"]) ? attributes.delete("type") : attributes["type"]
@@ -94,7 +95,7 @@ module Nori
     end
 
     def prefixed_attribute_name(attribute)
-      Nori.convert_tags? ? Nori.convert_tag(attribute) : attribute
+      @nori.convert_tags? ? @nori.convert_tag(attribute) : attribute
     end
 
     def add_node(node)
@@ -112,7 +113,7 @@ module Nori
 
       if @text
         t = typecast_value unnormalize_xml_entities(inner_html)
-        t = advanced_typecasting(t) if t.is_a?(String) && Nori.advanced_typecasting?
+        t = advanced_typecasting(t) if t.is_a?(String) && @nori.advanced_typecasting?
 
         if t.is_a?(String)
           t = StringWithAttributes.new(t)

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -632,6 +632,25 @@ describe Nori do
       end
 
     end
+
+    describe "using different nori" do
+      let(:parser) { parser }
+      let(:different_nori) do
+        module DifferentNori
+          extend Nori
+        end
+        DifferentNori.configure do |config|
+          config.convert_tags_to { |tag| tag.upcase }
+        end
+        DifferentNori
+      end
+
+      it "should transform with different nori" do
+        xml = "<SomeThing>xml</SomeThing>"
+        parse(xml).should == { "SomeThing" => "xml" }
+        different_nori.parse(xml, parser).should == { "SOMETHING" => "xml" }
+      end
+    end
   end
 
   def parse(xml)

--- a/spec/nori/parser_spec.rb
+++ b/spec/nori/parser_spec.rb
@@ -34,4 +34,21 @@ describe Nori::Parser do
     end
   end
 
+  describe ".parse with different nori" do
+    let(:other_nori) do
+      module OtherNori
+        extend Nori
+      end
+      OtherNori.configure do |config|
+        config.convert_tags_to { |tag| tag.upcase }
+      end
+      OtherNori
+    end
+
+    it "should load the parser to use and parse the given xml" do
+      parser.parse("<SomeThing>xml</SomeThing>").should == { "SomeThing" => "xml" }
+      parser.parse("<SomeThing>xml</SomeThing>", nil, other_nori).should == { "SOMETHING" => "xml" }
+    end
+  end
+
 end


### PR DESCRIPTION
Hi,

The way that `nori` config is global had some adverse effects on my project. We use `nori` in our test-suite to parse XML to Hash, but once we included the `savon` gem it started to break a bunch of our code due to the following snippet:

``` ruby
Nori.configure do |config|
  config.strip_namespaces = true
  config.convert_tags_to { |tag| tag.snakecase.to_sym }
end
```

We strictly use camel-case tags because of external API dependencies, and this was causing our tests to fail. We opted out of changing our usage to snake-case (even though we should), because then we weren't mirroring our external API dependencies. Instead, we decided to allow multiple configurations of `nori`, like:

``` ruby
module TestNori
  extend Nori
end
```

Calls to `TestNori.configure` would then be isolated from `Nori.configure`. This seemed a much quicker solution, and may be of use to others who plan to use `nori` in various contexts. Feel free to let me know what you think, I'd be happy to make any changes to help this get into the mainline gem.

CI: http://travis-ci.org/#!/hsume2/nori
