### PR TITLE
take xsi:type="xsd:base64Binary" attributes into account

### DIFF
--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -73,6 +73,17 @@ module Nori
       # leave the type alone if we don't know what it is
       @type = self.class.available_typecasts.include?(attributes["type"]) ? attributes.delete("type") : attributes["type"]
 
+      unless @type
+        val = attributes["xsi:type"]
+        val.gsub!(/^.*:/, '') if val
+        if self.class.available_typecasts.include?(val) 
+          attributes.delete("xsi:type")
+          @type = val
+        else
+          @type = attributes["xsi:type"]
+        end
+      end
+
       @nil_element = false
       attributes.keys.each do |key|
         if result = /^((.*):)?nil$/.match(key)


### PR DESCRIPTION
Hi!

I'm using savon to interact in SOAP with OTRS. The OTRS SOAP however is very peculiar and sends back data of the form:

``` xml
<s-gensym233 xsi:type="xsd:base64Binary">VmVydHJhZyAvIEvDvG5kaWd1bmc=</s-gensym233>
```

Which is not decoded by Nori because Nori seems to await a "type" attribute and not an "xsi:type" one.

I used this patch to make it work. I'm really not sure if this is the right way to do it. But if it is, it may be worth including it in Nori.

Best regards,
Dominique
