### PR TITLE
Improved xs:time/xs:date/xs:dateTime regular expression matcher

### DIFF
--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -16,13 +16,34 @@ module Nori
   class XMLUtilityNode
 
     # Simple xs:time Regexp.
-    XS_TIME = /\d{2}:\d{2}:\d{2}/
+    # Valid xs:time formats
+    # 13:20:00          1:20 PM
+    # 13:20:30.5555     1:20 PM and 30.5555 seconds
+    # 13:20:00-05:00    1:20 PM, US Eastern Standard Time
+    # 13:20:00Z         1:20 PM, Coordinated Universal Time (UTC)
+    # 00:00:00          midnight
+    # 24:00:00          midnight
+
+    XS_TIME = /^\d{2}:\d{2}:\d{2}[Z\.\-]?\d*:?\d*$/
 
     # Simple xs:date Regexp.
-    XS_DATE = /\d{4}-\d{2}-\d{2}/
+    # Valid xs:date formats
+    # 2004-04-12           April 12, 2004
+    # -0045-01-01          January 1, 45 BC
+    # 12004-04-12          April 12, 12004
+    # 2004-04-12-05:00     April 12, 2004, US Eastern Standard Time, which is 5 hours behind Coordinated Universal Time (UTC)
+    # 2004-04-12Z          April 12, 2004, Coordinated Universal Time (UTC)
+
+    XS_DATE = /^[-]?\d{4}-\d{2}-\d{2}[Z\-]?\d*:?\d*$/
 
     # Simple xs:dateTime Regexp.
-    XS_DATE_TIME = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+    # Valid xs:dateTime formats
+    # 2004-04-12T13:20:00           1:20 pm on April 12, 2004
+    # 2004-04-12T13:20:15.5         1:20 pm and 15.5 seconds on April 12, 2004
+    # 2004-04-12T13:20:00-05:00     1:20 pm on April 12, 2004, US Eastern Standard Time
+    # 2004-04-12T13:20:00Z          1:20 pm on April 12, 2004, Coordinated Universal Time (UTC)
+
+    XS_DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[\.Z\-]?\d*:?\d*$/
 
     def self.typecasts
       @@typecasts

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -134,15 +134,19 @@ describe Nori do
 
         it "should not transform Strings containing an xs:time String and more" do
           parse("<value>09:33:55Z is a time</value>")["value"].should == "09:33:55Z is a time"
+          parse("<value>09:33:55Z_is_a_file_name</value>")["value"].should == "09:33:55Z_is_a_file_name"
         end
 
         it "should not transform Strings containing an xs:date String and more" do
           parse("<value>1955-04-18-05:00 is a date</value>")["value"].should == "1955-04-18-05:00 is a date"
+          parse("<value>1955-04-18-05:00_is_a_file_name</value>")["value"].should == "1955-04-18-05:00_is_a_file_name"
         end
 
         it "should not transform Strings containing an xs:dateTime String and more" do
           parse("<value>1955-04-18T11:22:33-05:00 is a dateTime</value>")["value"].should ==
             "1955-04-18T11:22:33-05:00 is a dateTime"
+          parse("<value>1955-04-18T11:22:33-05:00_is_a_file_name</value>")["value"].should ==
+            "1955-04-18T11:22:33-05:00_is_a_file_name"
         end
 
         ["00-00-00", "0000-00-00", "0000-00-00T00:00:00", "0569-23-0141", "DS2001-19-1312654773", "e6:53:01:00:ce:b4:06"].each do |date_string|


### PR DESCRIPTION
Hi Daniel,

I've run into an issue while consuming a Savon SOAP response, a file name (doc-2011-09-09.pdf) containing a date string was converted into a date object, while it shouldn't be. 

After digging into Nori, I found the 'advanced_typecasting' method in 'XMLUtilityNode' class is using a flawed regular expression to match strings to convert, which causes this issue. 

I've updated the regular expression to make it work for me, and here's the commit for you to consider in case you want to update your code and gem.

Thanks.

Cheers,
Felix
