### PR TITLE
Improved the xs:time/xs:date/xs:dateTime matching regular expression again

### DIFF
--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -23,11 +23,12 @@ module Nori
     # 13:20:00          1:20 PM
     # 13:20:30.5555     1:20 PM and 30.5555 seconds
     # 13:20:00-05:00    1:20 PM, US Eastern Standard Time
+    # 13:20:00+02:00    1:20 PM, Central European Standard Time
     # 13:20:00Z         1:20 PM, Coordinated Universal Time (UTC)
     # 00:00:00          midnight
     # 24:00:00          midnight
 
-    XS_TIME = /^\d{2}:\d{2}:\d{2}[Z\.\-]?\d*:?\d*$/
+    XS_TIME = /^\d{2}:\d{2}:\d{2}[Z\.\-\+]?\d*:?\d*$/
 
     # Simple xs:date Regexp.
     # Valid xs:date formats

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -133,6 +133,10 @@ describe Nori do
           parse("<value>09:33:55Z</value>")["value"].should == Time.parse("09:33:55Z")
         end
 
+        it "should transform Strings matching the xs:time format ahead of utc to Time objects" do
+          parse("<value>09:33:55+02:00</value>")["value"].should == Time.parse("09:33:55+02:00")
+        end
+
         it "should transform Strings matching the xs:date format to Date objects" do
           parse("<value>1955-04-18-05:00</value>")["value"].should == Date.parse("1955-04-18-05:00")
         end


### PR DESCRIPTION
hi,

the regular expression introduced by this commit: e722316 didn't recognize time, date and dateTime strings ahead of utc. and it didn't allow datetime strings with seconds and an offset from utc.

cheers,
Meike
