### PR TITLE
There is issue in Savon with empty nodes filled with attributes in hash

### DIFF
--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -171,7 +171,7 @@ module Nori
               out.merge!( k => v.map{|e| e.to_hash[k]})
             end
           end
-          out.merge! prefixed_attributes unless attributes.empty?
+          #out.merge! prefixed_attributes unless attributes.empty?
           out = out.empty? ? nil : out
         end
 


### PR DESCRIPTION
Issue:  https://github.com/savonrb/savon/issues/314

Problem: When node is empty, it leaves it as hash and fills it with attributes.  This is wrong.
I commented line out...
