### PR TITLE
README.rd: it's snakecase, not snake_case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Nori lets you specify a custom formula to convert XML tags to Hash keys.
 Let me give you an example:
 
 ``` ruby
-parser = Nori.new(:convert_tags_to => lambda { |tag| tag.snake_case.to_sym })
+parser = Nori.new(:convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
 
 xml = '<userResponse><accountStatus>active</accountStatus></userResponse>'
 parser.parse(xml)  # => { :user_response => { :account_status => "active" }


### PR DESCRIPTION
Made a small fix to the README file. It was using the non-existent "snake_case" method when it should use "snakecase".
