### PR TITLE
Nokogiri should be a regular dependency

### DIFF
--- a/nori.gemspec
+++ b/nori.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "nori"
 
+  s.add_dependency "nokogiri", ">= 1.4.0"
+
   s.add_development_dependency "rake",     "~> 10.0"
-  s.add_development_dependency "nokogiri", ">= 1.4.0"
   s.add_development_dependency "rspec",    "~> 2.12"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
When using this gem in other gems or projects, 'nokogiri' has to be added to the gemspec or Gemfile for the parser to run. This makes that optional.
