### PR TITLE
Fixed the lines that caused warnings when running in debug mode

### DIFF
--- a/lib/nori/core_ext/string.rb
+++ b/lib/nori/core_ext/string.rb
@@ -5,9 +5,9 @@ class Nori
       # Returns the String in snake_case.
       def snakecase
         str = dup
-        str.gsub! /::/, '/'
-        str.gsub! /([A-Z]+)([A-Z][a-z])/, '\1_\2'
-        str.gsub! /([a-z\d])([A-Z])/, '\1_\2'
+        str.gsub!(/::/, '/')
+        str.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        str.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
         str.tr! ".", "_"
         str.tr! "-", "_"
         str.downcase!


### PR DESCRIPTION
Removes following warnings:

lib/nori/core_ext/string.rb:8: warning: ambiguous first argument; put parentheses or even spaces
lib/nori/core_ext/string.rb:9: warning: ambiguous first argument; put parentheses or even spaces
lib/nori/core_ext/string.rb:10: warning: ambiguous first argument; put parentheses or even spaces
