### PR TITLE
Refactor Hash#to_param method

### DIFF
--- a/lib/nori/core_ext/hash.rb
+++ b/lib/nori/core_ext/hash.rb
@@ -16,9 +16,7 @@ class Nori
       #   }.to_params
       #     #=> "name=Bob&address[city]=Ruby Central&address[phones][]=111-111-1111&address[phones][]=222-222-2222&address[street]=111 Ruby Ave."
       def to_params
-        params = self.map { |k, v| normalize_param(k,v) }.join
-        params.chop! # trailing &
-        params
+        map { |k, v| normalize_param(k,v) }.flatten.join('&')
       end
 
       # @param key<Object> The key for the param.
@@ -26,30 +24,15 @@ class Nori
       #
       # @return <String> This key value pair as a param
       #
-      # @example normalize_param(:name, "Bob Jones") #=> "name=Bob%20Jones&"
+      # @example normalize_param(:name, "Bob Jones") #=> "name=Bob%20Jones"
       def normalize_param(key, value)
-        param = ''
-        stack = []
-
         if value.is_a?(Array)
-          param << value.map { |element| normalize_param("#{key}[]", element) }.join
+          normalize_array_params(key, value)
         elsif value.is_a?(Hash)
-          stack << [key,value]
+          normalize_hash_params(key, value)
         else
-          param << "#{key}=#{URI.encode(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}&"
+          normalize_simple_type_params(key, value)
         end
-
-        stack.each do |parent, hash|
-          hash.each do |key, value|
-            if value.is_a?(Hash)
-              stack << ["#{parent}[#{key}]", value]
-            else
-              param << normalize_param("#{parent}[#{key}]", value)
-            end
-          end
-        end
-
-        param
       end
 
       # @return <String> The hash as attributes for an XML tag.
@@ -61,6 +44,28 @@ class Nori
         map do |k, v|
           %{#{k.to_s.snakecase.sub(/^(.{1,1})/) { |m| m.downcase }}="#{v}"}
         end.join(' ')
+      end
+
+      private
+
+      def normalize_simple_type_params(key, value)
+        ["#{key}=#{encode_simple_value(value)}"]
+      end
+
+      def normalize_array_params(key, array)
+        array.map do |element|
+          normalize_param("#{key}[]", element)
+        end
+      end
+
+      def normalize_hash_params(key, hash)
+        hash.map do |nested_key, element|
+          normalize_param("#{key}[#{nested_key}]", element)
+        end
+      end
+
+      def encode_simple_value(value)
+        URI.encode(value.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
       end
 
     end


### PR DESCRIPTION
Here are some changes that I made which simplify hash#to_param method:   
- extract some helper methods
- simplify hash param normalization

It's worth to point out that #normalize_param api has slightly changed - now it returns a list of strings. On the other hand it feels like it should be a private method anyway.
