### PR TITLE
Introduce :convert_dashes_to_underscores option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ parser = Nori.new(:convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
 xml = '<userResponse><accountStatus>active</accountStatus></userResponse>'
 parser.parse(xml)  # => { :user_response => { :account_status => "active" }
 ```
+
+Dashes and underscores
+----------------------
+
+Nori will automatically convert dashes in tag names to underscores.
+For example:
+
+```ruby
+parser = Nori.new
+parser.parse('<any-tag>foo bar</any-tag>')  # => { "any_tag" => "foo bar" }
+```
+
+You can control this behavior with the `:convert_dashes_to_underscores` option:
+
+```ruby
+parser = Nori.new(:convert_dashes_to_underscores => false)
+parser.parse('<any-tag>foo bar</any-tag>') # => { "any-tag" => "foo bar" }
+```

--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -5,7 +5,7 @@ require "nori/xml_utility_node"
 class Nori
 
   def self.hash_key(name, options = {})
-    name = name.tr("-", "_")
+    name = name.tr("-", "_") if options[:convert_dashes_to_underscores]
     name = name.split(":").last if options[:strip_namespaces]
     name = options[:convert_tags_to].call(name) if options[:convert_tags_to].respond_to? :call
     name
@@ -19,6 +19,7 @@ class Nori
       :delete_namespace_attributes  => false,
       :convert_tags_to              => nil,
       :advanced_typecasting         => true,
+      :convert_dashes_to_underscores => true,
       :parser                       => :nokogiri
     }
 

--- a/spec/nori/api_spec.rb
+++ b/spec/nori/api_spec.rb
@@ -162,6 +162,14 @@ describe Nori do
     end
   end
 
+  context "#parse with :convert_dashes_to_underscores" do
+    it "can be configured to skip dash to underscope conversion" do
+      xml = '<any-tag>foo bar</any-tag'
+      hash = nori(:convert_dashes_to_underscores => false).parse(xml)
+      hash.should == {'any-tag' => 'foo bar'}
+    end
+  end
+
   def nori(options = {})
     Nori.new(options)
   end


### PR DESCRIPTION
Currently nori will automatically convert all dashes in tag names to underscores. 

``` ruby
Nori.new.parse('<hello-world>Hi</hello-world>') # => " {"hello_world"=>"Hi"}
```

We want to use nori to test XML responses of our API. Some of our tag names contain dashes and some underscores. We would like to make the conversion behavior configurable.

This pull request introduces the `:convert_dashes_to_underscores`. It's enabled by default to not be a breaking change.
