### PR TITLE
Fix Nokogiri parser processing xml entity encoded characters

### DIFF
--- a/lib/nori/parser/nokogiri.rb
+++ b/lib/nori/parser/nokogiri.rb
@@ -19,15 +19,27 @@ class Nori
           stack.push Nori::XMLUtilityNode.new(options, name, Hash[*attrs.flatten])
         end
 
+        # To keep backward behaviour compatibility
+        # delete last child if it is a space-only text node
         def end_element(name)
           if stack.size > 1
             last = stack.pop
+            maybe_string = last.children.last
+            if maybe_string.is_a?(String) and maybe_string.strip.empty?
+              last.children.pop
+            end
             stack.last.add_node last
           end
         end
 
+        # If this node is a successive character then add it as is.
+        # First child being a space-only text node will not be added
+        # because there is no previous characters.
         def characters(string)
-          stack.last.add_node(string) unless string.strip.length == 0 || stack.empty?
+          last = stack.last
+          if last and last.children.last.is_a?(String) or string.strip.size > 0
+            last.add_node(string)
+          end
         end
 
         alias cdata_block characters


### PR DESCRIPTION
In Nori 2.4.0 there is a bug in a parser when it processes xml entity encoded characters
that is a common case for non-English SOAP applications.

For example, if we have the next node:

```
<ns0:ASSIGNEDGROUP>&#x414;&#x435;&#x436;&#x443;&#x440;&#x43D;&#x430;&#x44F; &#x441;&#x43C;&#x435;&#x43D;&#x430; &#x41B;&#x41F;1.5</ns0:ASSIGNEDGROUP>
```

and we want to convert it to hash using Nori with Nokogiri parser, it is expected to be:

``` ruby
{"ns0:ASSIGNEDGROUP"=>"Дежурная смена ЛП1.5"}
```

but current version of Nori converts it to:

``` ruby
{"ns0:ASSIGNEDGROUP"=>"ДежурнаясменаЛП1.5"}
```

since every whitespace in source xml lies between two other nodes and looks like a non-significant crap.

The present patch fixes this case, still not touching behaviour in any other way.
