### PR TITLE
Adds option to configure empty tag conversion

### DIFF
--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -15,13 +15,14 @@ class Nori
 
   def initialize(options = {})
     defaults = {
-      :strip_namespaces             => false,
-      :delete_namespace_attributes  => false,
-      :convert_tags_to              => nil,
-      :convert_attributes_to        => nil,
-      :advanced_typecasting         => true,
+      :strip_namespaces              => false,
+      :delete_namespace_attributes   => false,
+      :convert_tags_to               => nil,
+      :convert_attributes_to         => nil,
+      :empty_tag_value               => nil,
+      :advanced_typecasting          => true,
       :convert_dashes_to_underscores => true,
-      :parser                       => :nokogiri
+      :parser                        => :nokogiri
     }
 
     validate_options! defaults.keys, options.keys

--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -171,7 +171,7 @@ class Nori
             end
           end
           out.merge! prefixed_attributes unless attributes.empty?
-          out = out.empty? ? nil : out
+          out = out.empty? ? @options[:empty_tag_value] : out
         end
 
         if @type && out.nil?
@@ -247,7 +247,7 @@ class Nori
     end
     alias to_s to_html
 
-  private
+    private
     def try_to_convert(value, &block)
       block.call(value)
     rescue ArgumentError

--- a/spec/nori/api_spec.rb
+++ b/spec/nori/api_spec.rb
@@ -170,8 +170,15 @@ describe Nori do
     end
   end
 
+  context "#parse with :empty_tag_value set to empty string" do
+    it "can be configured to convert empty tags to given value" do
+      xml = "<parentTag><tag/></parentTag>"
+      hash = nori(:empty_tag_value => "").parse(xml)
+      expect(hash).to eq("parentTag" => { "tag" => "" })
+    end
+  end
+
   def nori(options = {})
     Nori.new(options)
   end
-
 end


### PR DESCRIPTION
Basically I have problem similar to described here  https://github.com/savonrb/nori/issues/35
So decided to add option that will be used for empty tags. By default value for empty tag is nil as was before but can be configured via empty_tag_value option. For example:
```
:empty_tag_value => ""
```