### PR TITLE
Implement error handling in Nokogiri parser

### DIFF
--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -3,6 +3,7 @@ require "nori/core_ext"
 require "nori/xml_utility_node"
 
 class Nori
+  class ParseError < StandardError; end
 
   def self.hash_key(name, options = {})
     name = name.tr("-", "_") if options[:convert_dashes_to_underscores]

--- a/lib/nori/parser/nokogiri.rb
+++ b/lib/nori/parser/nokogiri.rb
@@ -10,6 +10,7 @@ class Nori
 
       class Document < ::Nokogiri::XML::SAX::Document
         attr_accessor :options
+        attr_accessor :last_error
 
         def stack
           @stack ||= []
@@ -44,6 +45,9 @@ class Nori
 
         alias cdata_block characters
 
+        def error(message)
+          @last_error = message
+        end
       end
 
       def self.parse(xml, options)
@@ -51,6 +55,7 @@ class Nori
         document.options = options
         parser = ::Nokogiri::XML::SAX::Parser.new document
         parser.parse xml
+        raise ParseError, document.last_error if document.last_error
         document.stack.length > 0 ? document.stack.pop.to_hash : {}
       end
 

--- a/lib/nori/parser/rexml.rb
+++ b/lib/nori/parser/rexml.rb
@@ -15,7 +15,11 @@ class Nori
         parser = ::REXML::Parsers::BaseParser.new(xml)
 
         while true
-          raw_data = parser.pull
+          begin
+            raw_data = parser.pull
+          rescue ::REXML::ParseException => error
+            raise Nori::ParseError, error.message
+          end
           event = unnormalize(raw_data)
           case event[0]
           when :end_document

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -640,6 +640,10 @@ describe Nori do
         expect(parse(' ')).to eq({})
       end
 
+      it "raises error on missing end tag" do
+        expect { parse('<foo><bar>foo bar</foo>') }.to raise_error(Nori::ParseError)
+      end
+
     end
   end
 


### PR DESCRIPTION
If a parse error occurred anywhere inside the XML, the Nokogiri parser just returns whatever happens to be on top of the stack. This makes it very hard to troubleshoot the error down the line.

To avoid this we need to implement the `error` method and raise an error. This introduces a new exception type `Nori::ParseError` which we also need to raise in the REXML parser to make it symmetric.