### PR TITLE
fix 'undefined method for nil:NilClass' on wrong xmls

### DIFF
--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -46,6 +46,8 @@ class Nori
 
     parser = load_parser @options[:parser]
     parser.parse(cleaned_xml, @options)
+  rescue NoMethodError => e
+    raise ArgumentError, "Parsing error (#{e.message}), might be malformed xml"
   end
 
   private

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -640,6 +640,10 @@ describe Nori do
         expect(parse(' ')).to eq({})
       end
 
+      it "handle incorrect xml string" do
+        incorrect_xml = "<?xml version=\"1.0\" encoding=\"utf-8\">\n<request>\n <opcode>0</opcode>\n</request>\n"
+        expect { parse(incorrect_xml) }.to raise_error(ArgumentError, /Parsing error/)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #78 

https://github.com/savonrb/nori/pull/64 introduced a confusing error "undefined method" on malformed xmls.
This change reraise this error with the proper class and message.