### PR TITLE
gemspec: Drop unused rubyforge_project property

### DIFF
--- a/nori.gemspec
+++ b/nori.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = "nori"
   s.license = "MIT"
 
   s.add_development_dependency "rake",     "~> 10.0"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505