### PR TITLE
CI: Update patch versions in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 language: "ruby"
-script: "bundle exec rake"
-sudo: false
 rvm:
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - jruby
-  - rbx-2
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+  - jruby-9.2.12.0
+cache: bundler


### PR DESCRIPTION
This PR updates the Travis CI configuration.

- Drops unused `sudo: false` property. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
- updates the CI matrix to use latest JRuby, **9.2.12.0**. [JRuby 9.2.12.0 release blog post](https://www.jruby.org/2020/07/01/jruby-9-2-12-0.html)
- Cache the Bundler results in Travis (quicker!)