### PR TITLE
fix: API spec: Fix a typo, use complete XML in example

### DIFF
--- a/spec/nori/api_spec.rb
+++ b/spec/nori/api_spec.rb
@@ -156,8 +156,8 @@ describe Nori do
   end
 
   context "#parse with :convert_dashes_to_underscores" do
-    it "can be configured to skip dash to underscope conversion" do
-      xml = '<any-tag>foo bar</any-tag'
+    it "can be configured to skip dash to underscore conversion" do
+      xml = '<any-tag>foo bar</any-tag>'
       hash = nori(:convert_dashes_to_underscores => false).parse(xml)
       expect(hash).to eq({'any-tag' => 'foo bar'})
     end


### PR DESCRIPTION
  - The "it" description had a typo
  - This failed on JRuby, before adding the closing XML tag
  - This was repaired in passing, by @stenlarsson, thanks!

Co-authored-by: Sten Larsson 