### PR TITLE
spec: Avoid RSpec deprecation warning

### DIFF
--- a/spec/nori/core_ext/object_spec.rb
+++ b/spec/nori/core_ext/object_spec.rb
@@ -5,13 +5,13 @@ describe Object do
   describe "#blank?" do
     [nil, false, [], {}].each do |object|
       it "should return true for: #{object.inspect}" do
-        expect(object.blank?).to be_true
+        expect(object.blank?).to eq true
       end
     end
 
     [true, [nil], 1, "string", { :key => "value" }].each do |object|
       it "should return false for: #{object.inspect}" do
-        expect(object.blank?).to be_false
+        expect(object.blank?).to eq false
       end
     end
   end


### PR DESCRIPTION
This PR fixes an RSpec warning.

Warning was:
  > `be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead.