### PR TITLE
On Ruby 3, add rexml as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ platform :rbx do
   gem 'rubysl'
   gem 'rubinius-coverage'
 end
+
+if RUBY_VERSION >= "3"
+  gem "rexml", "~> 3.2"
+end


### PR DESCRIPTION
This made the tests pass. Perhaps this is not the best way to add `rexml` as a dependency.