### PR TITLE
CI: Use jruby-9.2.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.1
-  - jruby-9.2.12.0
+  - jruby-9.2.14.0
 cache: bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.14.0**.

[JRuby 9.2.14.0 release blog post](https://www.jruby.org/2020/12/08/jruby-9-2-14-0.html)

