### PR TITLE
rake 12.3.3

### DIFF
--- a/nori.gemspec
+++ b/nori.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake",     "~> 12.3.3"
   s.add_development_dependency "nokogiri", ">= 1.4.0"
-  s.add_development_dependency "rspec",    "~> 2.12"
+  s.add_development_dependency "rspec",    "~> 3.11.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/nori.gemspec
+++ b/nori.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.license = "MIT"
 
-  s.add_development_dependency "rake",     "~> 10.0"
+  s.add_development_dependency "rake",     "~> 12.3.3"
   s.add_development_dependency "nokogiri", ">= 1.4.0"
   s.add_development_dependency "rspec",    "~> 2.12"
 


### PR DESCRIPTION
resolves https://github.com/advisories/GHSA-jppv-gw3r-w3q8

rspec 2.x is not compatible with the minimum version of rake needed to resolve this issue, so it also had to be upgraded, but fortunately the tests are already compatible with rspec 3.x