### PR TITLE
Provide option to strip attributes for empty tags

### DIFF
--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -15,15 +15,16 @@ class Nori
 
   def initialize(options = {})
     defaults = {
-      :strip_namespaces              => false,
-      :delete_namespace_attributes   => false,
-      :convert_tags_to               => nil,
-      :convert_attributes_to         => nil,
-      :empty_tag_value               => nil,
-      :advanced_typecasting          => true,
-      :convert_dashes_to_underscores => true,
-      :scrub_xml                     => true,
-      :parser                        => :nokogiri
+      :strip_namespaces               => false,
+      :delete_namespace_attributes    => false,
+      :convert_tags_to                => nil,
+      :convert_attributes_to          => nil,
+      :empty_tag_value                => nil,
+      :advanced_typecasting           => true,
+      :convert_dashes_to_underscores  => true,
+      :scrub_xml                      => true,
+      :strip_attributes_of_empty_tags => false,
+      :parser                         => :nokogiri
     }
 
     validate_options! defaults.keys, options.keys

--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -170,7 +170,9 @@ class Nori
               out.merge!( k => v.map{|e| e.to_hash[k]})
             end
           end
-          out.merge! prefixed_attributes unless attributes.empty?
+          if !(@options[:strip_attributes_of_empty_tags] && @children.empty?) && attributes.any?
+            out.merge! prefixed_attributes
+          end
           out = out.empty? ? @options[:empty_tag_value] : out
         end
 

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -640,6 +640,53 @@ describe Nori do
         expect(parse(' ')).to eq({})
       end
 
+      context "with strip_attributes_of_empty_tags set to true" do
+        it "should strip attributes of empty tags" do
+          expect(parse('<foo bar="" />', strip_attributes_of_empty_tags: true)).to eq({ 'foo' => nil })
+        end
+
+        it "should strip attributes only of empty tags also in a nested structure" do
+          xml = <<-XML
+            <content>
+              <foo />
+              <foo bar="baz" />
+              <foo bar="baz" bar2="baz2"></foo>
+              <foo bar="baz">actual content</foo>
+            </content>
+          XML
+
+          expect(parse(xml, strip_attributes_of_empty_tags: true)).to match({
+            "content" => {
+              "foo" => [nil, nil, nil, be_a(Nori::StringWithAttributes).and(eq("actual content"))],
+            }
+          })
+        end
+      end
+
+      context "with strip_attributes_of_empty_tags set to false" do
+        it "should not strip any attributes" do
+          xml = <<-XML
+            <content>
+              <foo />
+              <foo bar="baz" />
+              <foo bar="baz" bar2="baz2"></foo>
+              <foo bar="baz">actual content</foo>
+            </content>
+          XML
+
+          expect(parse(xml, strip_attributes_of_empty_tags: false)).to match({
+            "content" => {
+              "foo" => [
+                nil,
+                {"@bar"=>"baz"},
+                {"@bar"=>"baz", "@bar2"=>"baz2"},
+                be_a(Nori::StringWithAttributes).and(eq("actual content"))
+              ],
+            }
+          })
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
Introduces a new option "`strip_attributes_of_empty_tags`" which can be used to ignore any attributes when an empty tag is found, in favour of consistent return types. This can be helpful if the parsed XML document mainly specifies namespaces or other attributes one might not be interested in to reduce the code needed during parsing.

My use case which motivated this feature was a bug I had when parsing a feed, which sometimes returned

```xml
<Street xmlns="...">MyStreet</Street>
<BuildingNumber xmlns="...">6</BuildingNumber>
```

but sometimes also 

```xml
<Street xmlns="...">MyStreet 6</Street>
<BuildingNumber xmlns="..." />
```

The code which processed the parsed feed looked something like

```ruby
Model.update(address: [parsed[:street], parsed[:building_number]].join(' '))
```

which (sometimes) produced addressed like `MyStreet {:@xmlns=>"..."}`.

Since I'm not interested in the attribute anyway, it would be easier to just strip them already while parsing. closes #97