### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,10 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
+          - '4.0'
           - 'head'
-          - jruby-9.4.5.0
+          - jruby-9.4.8
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/lib/nori/string_io_file.rb
+++ b/lib/nori/string_io_file.rb
@@ -1,3 +1,5 @@
+require "stringio"
+
 class Nori
   class StringIOFile < StringIO
 

--- a/nori.gemspec
+++ b/nori.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
 
   s.metadata["rubygems_mfa_required"] = "true"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files = `git ls-files lib`.split($/) + ["CHANGELOG.md", "LICENSE", "README.md"]
   s.require_paths = ["lib"]
 end

--- a/nori.gemspec
+++ b/nori.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_dependency "bigdecimal"
+  s.add_dependency "stringio"
 
-  s.add_development_dependency "rake",     "~> 12.3.3"
+  s.add_development_dependency "rake",     "~> 13.3"
   s.add_development_dependency "nokogiri", ">= 1.4.0"
   s.add_development_dependency "rspec",    "~> 3.11.0"
 


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar.gz

$ git switch reduce-gem-size

$ gem build -o after.tar.gz

$ du -sh before.tar.gz after.tar.gz
 24K 	before
 16K 	after
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 24K    | 16K   | −8K (⏷ −33.33%)      |


###  whitch files was deleted?

```diff
data
-├── .devcontainer
-│   └── devcontainer.json
-├── .github
-│   ├── dependabot.yml
-│   └── workflows
-│       └── test.yml
-├── .gitignore
-├── .rspec
-├── benchmark
-│   ├── benchmark.rb
-│   └── soap_response.xml
 ├── CHANGELOG.md
-├── Gemfile
 ├── lib
 │   ├── nori
 │   │   ├── core_ext
 │   │   │   └── hash.rb
 │   │   ├── core_ext.rb
 │   │   ├── parser
 │   │   │   ├── nokogiri.rb
 │   │   │   └── rexml.rb
 │   │   ├── string_io_file.rb
 │   │   ├── string_utils.rb
 │   │   ├── string_with_attributes.rb
 │   │   ├── version.rb
 │   │   └── xml_utility_node.rb
 │   └── nori.rb
 ├── LICENSE
-├── nori.gemspec
-├── Rakefile
 ├── README.md
-└── spec
-    ├── nori
-    │   ├── api_spec.rb
-    │   ├── core_ext
-    │   │   └── hash_spec.rb
-    │   ├── nori_spec.rb
-    │   └── string_utils_spec.rb
-    └── spec_helper.rb


```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)