### PR TITLE
Add consistent_empty_tags option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Feature: [#97](https://github.com/savonrb/nori/issues/97) Add the `:consistent_empty_tags` option ([#109](https://github.com/savonrb/nori/pull/109)). When enabled, every empty tag becomes the `:empty_tag_value`, whether it has attributes or not. A string value keeps the attributes accessible via `#attributes`, and an explicit `xsi:nil="true"` always becomes `nil`. Reported by @lukasbischof, who also proposed a fix in [#98](https://github.com/savonrb/nori/pull/98). Thanks to @md5 for surfacing another instance of it and pinpointing the cause.
+
 # 2.7.1 (2024-07-28)
 
 * Stop monkey-patching String with #snakecase by @mchu in https://github.com/savonrb/nori/pull/102

--- a/README.md
+++ b/README.md
@@ -107,3 +107,48 @@ parser = Nori.new(:convert_dashes_to_underscores => false)
 parser.parse('<any-tag>foo bar</any-tag>')
 # => {"any-tag"=>"foo bar"}
 ```
+
+## empty_tag_value
+
+By default, an empty tag becomes `nil`. The `empty_tag_value` option replaces that value.
+
+```ruby
+Nori.new.parse('<foo/>')
+# => {"foo"=>nil}
+
+Nori.new(:empty_tag_value => "").parse('<foo/>')
+# => {"foo"=>""}
+```
+
+The option does not apply to empty tags with attributes.
+They become a hash of their prefixed attributes instead.
+
+```ruby
+Nori.new(:empty_tag_value => "").parse('<foo bar="baz"/>')
+# => {"foo"=>{"@bar"=>"baz"}}
+```
+
+## consistent_empty_tags
+
+With `consistent_empty_tags`, every empty tag (with or without attributes) becomes the `empty_tag_value`.
+
+```ruby
+Nori.new(:consistent_empty_tags => true).parse('<foo bar="baz"/>')
+# => {"foo"=>nil}
+```
+
+A string `empty_tag_value` keeps the attributes accessible on the value,
+and an explicit `xsi:nil="true"` always becomes `nil`.
+
+```ruby
+parser = Nori.new(:consistent_empty_tags => true, :empty_tag_value => "")
+
+result = parser.parse('<foo bar="baz"/>')
+# => {"foo"=>""}
+
+result["foo"].attributes
+# => {"bar"=>"baz"}
+
+parser.parse('<foo xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>')
+# => {"foo"=>nil}
+```

--- a/lib/nori.rb
+++ b/lib/nori.rb
@@ -20,6 +20,7 @@ class Nori
       :convert_tags_to               => nil,
       :convert_attributes_to         => nil,
       :empty_tag_value               => nil,
+      :consistent_empty_tags         => false,
       :advanced_typecasting          => true,
       :convert_dashes_to_underscores => true,
       :scrub_xml                     => true,

--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -252,6 +252,8 @@ class Nori
     # Folds the child nodes and the prefixed attributes into a hash.
     # An empty result becomes the :empty_tag_value option.
     def hash_value(groups)
+      return consistent_empty_value if @options[:consistent_empty_tags] && groups.empty?
+
       value = {}
       groups.each do |child_name, nodes|
         if nodes.size == 1
@@ -262,6 +264,18 @@ class Nori
       end
       value.merge!(prefixed_attributes) unless attributes.empty?
       value.empty? ? @options[:empty_tag_value] : value
+    end
+
+    # Resolves an element without children and without text when the
+    # :consistent_empty_tags option is set. The element becomes the
+    # :empty_tag_value option no matter which attributes it carries.
+    # A string value keeps the attributes accessible on the value.
+    # An explicit xsi:nil="true" wins over the option and becomes nil.
+    def consistent_empty_value
+      return nil if @nil_element
+
+      value = @options[:empty_tag_value]
+      value.is_a?(String) ? string_with_attributes(value) : value
     end
 
     # Wraps a string value so the node's attributes stay accessible

--- a/lib/nori/xml_utility_node.rb
+++ b/lib/nori/xml_utility_node.rb
@@ -127,59 +127,21 @@ class Nori
       @children << node
     end
 
+    # Converts the node into a hash with the node name as its single key.
+    #
+    # The value depends on the shape of the node. A node typed as "file"
+    # becomes a {StringIOFile}. A node with text content becomes a typecast
+    # scalar. Every other node folds its children into an array or a hash.
+    #
+    # @return [Hash{String => Object}] the node name mapped to its value
     def to_hash
-      if @type == "file"
-        f = StringIOFile.new((@children.first || '').unpack('m').first)
-        f.original_filename = attributes['name'] || 'untitled'
-        f.content_type = attributes['content_type'] || 'application/octet-stream'
-        return { name => f }
-      end
+      return { name => file_value } if @type == "file"
+      return { name => text_value } if @text
 
-      if @text
-        t = typecast_value(inner_html)
-        t = advanced_typecasting(t) if t.is_a?(String) && @options[:advanced_typecasting]
-
-        if t.is_a?(String)
-          t = StringWithAttributes.new(t)
-          t.attributes = attributes
-        end
-
-        return { name => t }
-      else
-        #change repeating groups into an array
-        groups = @children.inject({}) { |s,e| (s[e.name] ||= []) << e; s }
-
-        out = nil
-        if @type == "array"
-          out = []
-          groups.each do |k, v|
-            if v.size == 1
-              out << v.first.to_hash.entries.first.last
-            else
-              out << v.map{|e| e.to_hash[k]}
-            end
-          end
-          out = out.flatten
-
-        else # If Hash
-          out = {}
-          groups.each do |k,v|
-            if v.size == 1
-              out.merge!(v.first)
-            else
-              out.merge!( k => v.map{|e| e.to_hash[k]})
-            end
-          end
-          out.merge! prefixed_attributes unless attributes.empty?
-          out = out.empty? ? @options[:empty_tag_value] : out
-        end
-
-        if @type && out.nil?
-          { name => typecast_value(out) }
-        else
-          { name => out }
-        end
-      end
+      groups = group_children
+      value = @type == "array" ? array_value(groups) : hash_value(groups)
+      value = typecast_value(value) if @type && value.nil?
+      { name => value }
     end
 
     # Typecasts a value based upon its type. For instance, if
@@ -248,6 +210,68 @@ class Nori
     alias to_s to_html
 
     private
+
+    # Decodes the base64 content of a node typed as "file" into a
+    # {StringIOFile} carrying the filename and content type attributes.
+    def file_value
+      file = StringIOFile.new((@children.first || '').unpack('m').first)
+      file.original_filename = attributes['name'] || 'untitled'
+      file.content_type = attributes['content_type'] || 'application/octet-stream'
+      file
+    end
+
+    # Typecasts the text content of the node. String results are wrapped
+    # so the node's attributes stay accessible on the value.
+    def text_value
+      value = typecast_value(inner_html)
+      value = advanced_typecasting(value) if value.is_a?(String) && @options[:advanced_typecasting]
+      value.is_a?(String) ? string_with_attributes(value) : value
+    end
+
+    # Groups the child nodes by their name so repeating siblings can be
+    # folded into arrays.
+    #
+    # @return [Hash{String => Array<XMLUtilityNode>}]
+    def group_children
+      @children.inject({}) { |hash, child| (hash[child.name] ||= []) << child; hash }
+    end
+
+    # Collects the values of all child nodes for a node typed as "array".
+    def array_value(groups)
+      values = []
+      groups.each do |child_name, nodes|
+        if nodes.size == 1
+          values << nodes.first.to_hash.entries.first.last
+        else
+          values << nodes.map { |node| node.to_hash[child_name] }
+        end
+      end
+      values.flatten
+    end
+
+    # Folds the child nodes and the prefixed attributes into a hash.
+    # An empty result becomes the :empty_tag_value option.
+    def hash_value(groups)
+      value = {}
+      groups.each do |child_name, nodes|
+        if nodes.size == 1
+          value.merge!(nodes.first.to_hash)
+        else
+          value.merge!(child_name => nodes.map { |node| node.to_hash[child_name] })
+        end
+      end
+      value.merge!(prefixed_attributes) unless attributes.empty?
+      value.empty? ? @options[:empty_tag_value] : value
+    end
+
+    # Wraps a string value so the node's attributes stay accessible
+    # through {StringWithAttributes#attributes}.
+    def string_with_attributes(value)
+      string = StringWithAttributes.new(value)
+      string.attributes = attributes
+      string
+    end
+
     def try_to_convert(value, &block)
       block.call(value)
     rescue ArgumentError

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -640,6 +640,27 @@ describe Nori do
         expect(parse(' ')).to eq({})
       end
 
+      context "empty tags with the default options" do
+
+        it "returns the prefixed attributes for a whitespace-only tag with attributes" do
+          expect(parse('<foo bar="baz">   </foo>')).to eq("foo" => { "@bar" => "baz" })
+        end
+
+        it "returns the prefixed attributes when xsi:nil is combined with other attributes" do
+          xml = '<foo xsi:nil="true" bar="baz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>'
+          expect(parse(xml)).to eq("foo" => { "@bar" => "baz" })
+        end
+
+        it "ignores :empty_tag_value for an empty tag with attributes" do
+          expect(parse('<foo bar="baz"/>', :empty_tag_value => "")).to eq("foo" => { "@bar" => "baz" })
+        end
+
+        it "applies :empty_tag_value to an empty tag with an explicit xsi:nil" do
+          xml = '<foo xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>'
+          expect(parse(xml, :empty_tag_value => "")).to eq("foo" => "")
+        end
+      end
+
     end
   end
 

--- a/spec/nori/nori_spec.rb
+++ b/spec/nori/nori_spec.rb
@@ -661,6 +661,69 @@ describe Nori do
         end
       end
 
+      context "empty tags with :consistent_empty_tags" do
+
+        it "returns :empty_tag_value for an empty tag with attributes" do
+          expect(parse('<foo bar="baz"/>', :consistent_empty_tags => true)).to eq("foo" => nil)
+        end
+
+        it "returns :empty_tag_value for a whitespace-only tag with attributes" do
+          expect(parse('<foo bar="baz">   </foo>', :consistent_empty_tags => true)).to eq("foo" => nil)
+        end
+
+        it "returns :empty_tag_value for an empty tag without attributes" do
+          expect(parse('<foo/>', :consistent_empty_tags => true)).to eq("foo" => nil)
+        end
+
+        context "and :empty_tag_value set to an empty string" do
+
+          it "returns the string for an empty tag without attributes" do
+            expect(parse_consistent("<foo/>")).to eq("foo" => "")
+          end
+
+          it "attaches the attributes of an empty tag to the string" do
+            value = parse_consistent('<foo bar="baz"/>')["foo"]
+            expect(value).to eq("")
+            expect(value).to be_a(Nori::StringWithAttributes)
+            expect(value.attributes).to eq("bar" => "baz")
+          end
+
+          it "attaches the attributes of a whitespace-only tag to the string" do
+            value = parse_consistent('<foo bar="baz">   </foo>')["foo"]
+            expect(value).to eq("")
+            expect(value.attributes).to eq("bar" => "baz")
+          end
+
+          it "returns nil for an explicit xsi:nil" do
+            xml = '<foo xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>'
+            expect(parse_consistent(xml)).to eq("foo" => nil)
+          end
+
+          it "returns nil for an explicit xsi:nil combined with other attributes" do
+            xml = '<foo xsi:nil="true" bar="baz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>'
+            expect(parse_consistent(xml)).to eq("foo" => nil)
+          end
+
+          it "does not change tags with text" do
+            expect(parse_consistent("<foo>text</foo>")).to eq("foo" => "text")
+          end
+
+          it "does not change tags with children" do
+            # the attribute would be lost if the empty-tag rule also covered elements with children
+            xml = '<foo bar="baz"><child>x</child></foo>'
+            expect(parse_consistent(xml)).to eq("foo" => { "@bar" => "baz", "child" => "x" })
+          end
+
+          it "does not change empty tags typed as array" do
+            expect(parse_consistent('<foo type="array"/>')).to eq("foo" => [])
+          end
+
+          def parse_consistent(xml)
+            parse(xml, :consistent_empty_tags => true, :empty_tag_value => "")
+          end
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
The type of an empty tag's value historically depends on its attributes:
* a plain empty tag becomes the :empty_tag_value
* a tag with attributes becomes a hash of the prefixed attributes

Callers cannot rely on a stable type for the same element across payloads.

With :consistent_empty_tags, the :empty_tag_value applies to every empty tag, whether it has attributes or not:
* a string value keeps the attributes accessible on the value, matching how text nodes carry theirs
* an explicit xsi:nil="true" wins over the option and becomes nil, honoring the document's own signal
* tags with text or children, and tags typed as "array", are unaffected

The option is off by default.
Without it, parsing behaves exactly as before.